### PR TITLE
PR #30: B-7a — Crane Day Scaffold + Countdown + Set Complete

### DIFF
--- a/orchestration-v2/buyer/RATIONALE.md
+++ b/orchestration-v2/buyer/RATIONALE.md
@@ -51,3 +51,30 @@ This document correlates the UI features seen in the `buyer_dashboard.html` mock
 - Full-height layout fills viewport between nav and tab bar — no page scroll, thread scrolls internally
 
 **Rationale:** The single-thread design is a deliberate product decision, not a missing feature. In the managed marketplace model, Annie's complexity is Yardstake's problem — she should never need to decide who to contact. Fiona is the single point of contact, and the UI makes this feel like a premium concierge service rather than a limitation. The system event pills serve as an ambient project timeline: Annie can scroll up and reconstruct the entire journey from within the message thread without navigating away. The quick-reply chips lower the activation energy for common questions — reducing ghosting and improving Annie's sense of being actively engaged with her project.
+
+---
+
+## Screen 10: `buyer_crane_day.html`
+
+**File:** `orchestration-v2/buyer/buyer_crane_day.html`
+
+**UI Features (States 1 and 3 — PR #30; States 2 and 2b added in PR #31):**
+- 4-state machine: `countdown` → `live` → `spectator` → `set-complete`
+- Demo state-switcher panel (same dashed-border pattern as other buyer mocks)
+- Nav swap: authenticated nav + tab bar hidden in spectator state (logo only)
+
+**State 1 — Countdown:**
+- Live `setInterval` countdown to April 14, 2026 8:00 AM PST with 4 gradient-text digit units
+- Delivery details card (date, location, unit, crane operator, what to expect)
+- Fiona note card
+- Share button reveals inline card with fake spectator URL + "Copy Link" (clipboard API + toast)
+
+**State 3 — Set Complete:**
+- CSS confetti burst (same `spawnConfetti()` pattern as `buyer_deposit.html`) fires on state entry
+- Animated emerald pulse ring around checkmark icon
+- Hero photo: ADU on foundation (Unsplash)
+- Stats row: arrival time, set time, duration, zero incidents
+- Fiona wrap-up note
+- "Back to My Project" + "Share Your Photo" CTAs
+
+**Rationale:** Crane Day is the emotional peak of the entire buyer journey — the "Move That Bus" moment. The countdown timer makes the event feel imminent and concrete; Annie can share it with family the way you'd share a flight tracker. The confetti + "Your ADU is home!" heading on set-complete mirrors the deposit screen's celebration, creating a bookend: Annie felt this same delight when she put down her first $5K, and she feels it again when the unit lands. The spectator mode nav stripping is a deliberate trust signal — public viewers see nothing about Annie's financials, project details, or account. The emotional energy is preserved; the privacy boundary is absolute. Full rationale for States 2 and 2b (live chat, GPS tracker, spectator content) added in PR #31.

--- a/orchestration-v2/buyer/buyer_crane_day.html
+++ b/orchestration-v2/buyer/buyer_crane_day.html
@@ -1,0 +1,432 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Crane Day — Yardstake</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="https://unpkg.com/lucide@latest"></script>
+  <style>
+    body { font-family: 'Plus Jakarta Sans', sans-serif; background-color: #F8FAFC; color: #0F172A; }
+    .glass-card { background: rgba(255,255,255,0.9); backdrop-filter: blur(10px); border: 1px solid rgba(226,232,240,0.8); }
+    .gradient-text { background: linear-gradient(to right, #2563EB, #06B6D4); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+
+    /* State machine */
+    .state { display: none; }
+    .state.active { display: block; }
+
+    /* Confetti */
+    @keyframes confetti-fall {
+      0%   { transform: translateY(-20px) rotate(0deg); opacity: 1; }
+      100% { transform: translateY(80px) rotate(720deg); opacity: 0; }
+    }
+    .confetti-piece {
+      position: absolute;
+      width: 8px; height: 8px;
+      border-radius: 2px;
+      animation: confetti-fall 1.2s ease-out forwards;
+    }
+
+    /* Countdown digits */
+    .countdown-unit { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+    .countdown-digit {
+      font-size: 3.5rem;
+      font-weight: 800;
+      line-height: 1;
+      background: linear-gradient(135deg, #2563EB, #06B6D4);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      min-width: 3.5rem;
+      text-align: center;
+    }
+    @media (max-width: 480px) { .countdown-digit { font-size: 2.2rem; min-width: 2.4rem; } }
+    .countdown-label { font-size: 0.65rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: #94A3B8; }
+
+    /* Share card */
+    #share-card { display: none; }
+    #share-card.visible { display: block; }
+
+    /* Toast */
+    #toast {
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(20px);
+      background: #0F172A; color: #fff; padding: 10px 20px; border-radius: 999px;
+      font-size: 13px; font-weight: 600; opacity: 0; transition: opacity 0.2s, transform 0.2s;
+      pointer-events: none; z-index: 999; white-space: nowrap;
+    }
+    #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+    /* Emerald pulse ring for set-complete */
+    @keyframes ring-pulse { 0%,100% { box-shadow: 0 0 0 0 rgba(16,185,129,0.4); } 50% { box-shadow: 0 0 0 16px rgba(16,185,129,0); } }
+    .checkmark-ring { animation: ring-pulse 2s ease-in-out infinite; }
+
+    /* Live states placeholder notice */
+    .placeholder-state { border: 2px dashed #CBD5E1; border-radius: 16px; padding: 48px 24px; text-align: center; color: #94A3B8; }
+  </style>
+</head>
+<body class="antialiased min-h-screen flex flex-col">
+
+  <!-- ══════════════════════════
+       SHARED: Authenticated nav
+       (hidden in spectator mode via JS)
+       ══════════════════════════ -->
+  <nav id="main-nav" class="bg-white border-b border-slate-200 sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+      <div class="flex items-center space-x-2">
+        <i data-lucide="home" class="w-5 h-5 text-blue-600"></i>
+        <span class="text-xl font-bold tracking-tight">Yard<span class="text-cyan-500">stake</span></span>
+      </div>
+      <div id="nav-authenticated" class="flex items-center space-x-3">
+        <a href="buyer_messages.html" class="flex items-center space-x-2 bg-blue-50 border border-blue-100 px-3 py-1.5 rounded-full hover:bg-blue-100 transition-colors">
+          <img src="https://i.pravatar.cc/100?img=32" class="w-5 h-5 rounded-full object-cover" alt="Fiona">
+          <span class="text-xs font-bold text-blue-700">Message Fiona</span>
+        </a>
+        <button class="relative p-2 rounded-full hover:bg-slate-100 transition-colors">
+          <i data-lucide="bell" class="w-5 h-5 text-slate-500"></i>
+          <span class="absolute top-1 right-1 w-2 h-2 bg-orange-500 rounded-full"></span>
+        </button>
+        <div class="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-bold">A</div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Secondary tab bar (hidden in spectator mode) -->
+  <div id="tab-bar" class="bg-white border-b border-slate-200 sticky top-16 z-40">
+    <div class="max-w-7xl mx-auto px-6 flex space-x-8">
+      <a href="buyer_project_hub.html" class="py-3 text-sm font-semibold border-b-2 border-blue-600 text-blue-700 whitespace-nowrap">My Project</a>
+      <a href="buyer_report.html" class="py-3 text-sm font-semibold border-b-2 border-transparent text-slate-500 hover:text-slate-700 transition-colors whitespace-nowrap">My Report</a>
+      <a href="buyer_messages.html" class="py-3 text-sm font-semibold border-b-2 border-transparent text-slate-500 hover:text-slate-700 transition-colors whitespace-nowrap">Messages</a>
+    </div>
+  </div>
+
+  <main class="flex-grow max-w-2xl mx-auto w-full px-6 py-8 space-y-6">
+
+    <!-- Demo state switcher -->
+    <div class="border-2 border-dashed border-slate-300 rounded-2xl p-4">
+      <p class="text-xs font-bold text-slate-400 uppercase tracking-widest mb-3">Demo: Switch State</p>
+      <div class="flex flex-wrap gap-2">
+        <button id="btn-countdown"  onclick="showState('countdown')"  class="switcher-btn text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors bg-blue-600 text-white border-blue-600">Countdown</button>
+        <button id="btn-live"       onclick="showState('live')"       class="switcher-btn text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors bg-white text-slate-600 border-slate-300 hover:border-slate-400">Live — Crane Day</button>
+        <button id="btn-spectator"  onclick="showState('spectator')"  class="switcher-btn text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors bg-white text-slate-600 border-slate-300 hover:border-slate-400">Spectator Mode</button>
+        <button id="btn-set-complete" onclick="showState('set-complete')" class="switcher-btn text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors bg-white text-slate-600 border-slate-300 hover:border-slate-400">Set Complete</button>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════
+         STATE 1: COUNTDOWN
+         ══════════════════════════════════════ -->
+    <div id="state-countdown" class="state space-y-6">
+
+      <!-- Header -->
+      <div class="text-center space-y-1">
+        <p class="text-xs font-bold uppercase tracking-widest text-blue-500">Crane Day is coming</p>
+        <h1 class="text-2xl font-extrabold text-slate-900">Your ADU lands <span class="gradient-text">April 14, 2026</span></h1>
+        <p class="text-sm text-slate-500">742 SE Morrison St, Portland, OR</p>
+      </div>
+
+      <!-- Countdown timer -->
+      <div class="glass-card rounded-2xl px-6 py-8">
+        <div class="flex items-center justify-center gap-4 sm:gap-8">
+          <div class="countdown-unit">
+            <span id="cd-days" class="countdown-digit">00</span>
+            <span class="countdown-label">Days</span>
+          </div>
+          <span class="text-3xl font-extrabold text-slate-300 pb-5">:</span>
+          <div class="countdown-unit">
+            <span id="cd-hours" class="countdown-digit">00</span>
+            <span class="countdown-label">Hours</span>
+          </div>
+          <span class="text-3xl font-extrabold text-slate-300 pb-5">:</span>
+          <div class="countdown-unit">
+            <span id="cd-minutes" class="countdown-digit">00</span>
+            <span class="countdown-label">Minutes</span>
+          </div>
+          <span class="text-3xl font-extrabold text-slate-300 pb-5">:</span>
+          <div class="countdown-unit">
+            <span id="cd-seconds" class="countdown-digit">00</span>
+            <span class="countdown-label">Seconds</span>
+          </div>
+        </div>
+        <p class="text-center text-xs text-slate-400 mt-4">Until crane arrival · April 14, 2026 · 8:00 AM PST</p>
+      </div>
+
+      <!-- Delivery details -->
+      <div class="glass-card rounded-2xl px-6 py-5 space-y-4">
+        <h2 class="text-base font-bold text-slate-900 flex items-center gap-2">
+          <i data-lucide="truck" class="w-4 h-4 text-blue-500"></i>
+          Delivery Details
+        </h2>
+        <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+          <div>
+            <dt class="text-xs text-slate-400 font-medium">Date & Time</dt>
+            <dd class="font-semibold text-slate-800 mt-0.5">April 14, 2026 · 8:00 AM</dd>
+          </div>
+          <div>
+            <dt class="text-xs text-slate-400 font-medium">Crane Operator</dt>
+            <dd class="font-semibold text-slate-800 mt-0.5">Pacific Lift Co.</dd>
+          </div>
+          <div class="col-span-2">
+            <dt class="text-xs text-slate-400 font-medium">Location</dt>
+            <dd class="font-semibold text-slate-800 mt-0.5">742 SE Morrison St, Portland, OR 97214</dd>
+          </div>
+          <div class="col-span-2">
+            <dt class="text-xs text-slate-400 font-medium">Unit</dt>
+            <dd class="font-semibold text-slate-800 mt-0.5">Cascadia Studio 480</dd>
+          </div>
+          <div class="col-span-2">
+            <dt class="text-xs text-slate-400 font-medium">What to Expect</dt>
+            <dd class="text-slate-600 mt-0.5 leading-relaxed">The crane typically takes 2–3 hours. Your unit will be lifted over the main house and set on the foundation. You're welcome to be there!</dd>
+          </div>
+        </dl>
+      </div>
+
+      <!-- Fiona note -->
+      <div class="glass-card rounded-2xl px-5 py-4 flex items-start gap-3">
+        <img src="https://i.pravatar.cc/100?img=32" class="w-9 h-9 rounded-full object-cover flex-shrink-0 mt-0.5" alt="Fiona">
+        <div>
+          <p class="text-xs font-bold text-slate-700 mb-1">Fiona · Project Coordinator</p>
+          <p class="text-sm text-slate-600 leading-relaxed">"I confirmed everything with Backyard Bill this morning. Crane shows up at 8, usually done by 11. You can stand in the driveway — bring your phone for photos! I'll be monitoring remotely."</p>
+        </div>
+      </div>
+
+      <!-- Share button -->
+      <div class="glass-card rounded-2xl px-6 py-5 space-y-3">
+        <button
+          onclick="document.getElementById('share-card').classList.toggle('visible')"
+          class="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 rounded-xl transition-colors text-sm shadow-lg shadow-blue-200"
+        >
+          <i data-lucide="share-2" class="w-4 h-4"></i>
+          Invite Friends &amp; Family to Watch Live 🏗
+        </button>
+
+        <div id="share-card" class="bg-slate-50 border border-slate-200 rounded-xl px-4 py-4 space-y-3">
+          <p class="text-xs text-slate-500">Anyone with this link can watch — no account required.</p>
+          <div class="flex items-center gap-2">
+            <code class="flex-1 text-xs bg-white border border-slate-200 rounded-lg px-3 py-2 text-slate-700 truncate select-all">
+              https://watch.yardstake.com/annie-adu-apr14
+            </code>
+            <button
+              onclick="copyShareLink()"
+              class="flex-shrink-0 text-xs font-bold bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg transition-colors"
+            >
+              Copy Link
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- end state-countdown -->
+
+
+    <!-- ══════════════════════════════════════
+         STATE 2: LIVE (placeholder — filled in #31)
+         ══════════════════════════════════════ -->
+    <div id="state-live" class="state">
+      <div class="placeholder-state">
+        <i data-lucide="construction" class="w-8 h-8 mx-auto mb-3 text-slate-300"></i>
+        <p class="text-sm font-semibold">Live — Crane Day</p>
+        <p class="text-xs mt-1">Pulsing LIVE badge · GPS tracker · Family chat · Built in PR #31</p>
+      </div>
+    </div>
+
+
+    <!-- ══════════════════════════════════════
+         STATE 2b: SPECTATOR (placeholder — filled in #31)
+         ══════════════════════════════════════ -->
+    <div id="state-spectator" class="state">
+      <div class="placeholder-state">
+        <i data-lucide="eye" class="w-8 h-8 mx-auto mb-3 text-slate-300"></i>
+        <p class="text-sm font-semibold">Spectator Mode</p>
+        <p class="text-xs mt-1">Stripped nav · Public viewer · Built in PR #31</p>
+        <button onclick="showState('live')" class="mt-4 text-xs font-semibold text-blue-600 hover:underline">← Back to My View</button>
+      </div>
+    </div>
+
+
+    <!-- ══════════════════════════════════════
+         STATE 3: SET COMPLETE
+         ══════════════════════════════════════ -->
+    <div id="state-set-complete" class="state space-y-6">
+
+      <!-- Confetti container -->
+      <div id="confetti-container" class="relative h-12 overflow-visible mb-2 pointer-events-none" aria-hidden="true"></div>
+
+      <!-- Hero celebration -->
+      <div class="glass-card rounded-2xl px-6 py-8 text-center space-y-4">
+        <div class="checkmark-ring w-20 h-20 rounded-full bg-emerald-100 border-4 border-emerald-400 flex items-center justify-center mx-auto">
+          <i data-lucide="check" class="w-10 h-10 text-emerald-600"></i>
+        </div>
+        <div>
+          <h1 class="text-3xl font-extrabold text-slate-900">Your ADU is home! 🏠</h1>
+          <p class="text-slate-500 mt-1 text-sm">742 SE Morrison St, Portland, OR</p>
+        </div>
+      </div>
+
+      <!-- Hero photo -->
+      <div class="rounded-2xl overflow-hidden">
+        <img
+          src="https://images.unsplash.com/photo-1558618666-fcd25c85cd64?auto=format&fit=crop&w=800&q=80"
+          alt="ADU set on foundation"
+          class="w-full h-64 object-cover"
+        >
+      </div>
+
+      <!-- Stats row -->
+      <div class="glass-card rounded-2xl px-6 py-4">
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+          <div>
+            <p class="text-lg font-extrabold text-slate-900">8:00 AM</p>
+            <p class="text-xs text-slate-500 mt-0.5">Crane Arrived</p>
+          </div>
+          <div>
+            <p class="text-lg font-extrabold text-slate-900">10:42 AM</p>
+            <p class="text-xs text-slate-500 mt-0.5">Unit Set</p>
+          </div>
+          <div>
+            <p class="text-lg font-extrabold text-slate-900">2h 42m</p>
+            <p class="text-xs text-slate-500 mt-0.5">Total Time</p>
+          </div>
+          <div>
+            <p class="text-lg font-extrabold text-emerald-600">Zero</p>
+            <p class="text-xs text-slate-500 mt-0.5">Incidents</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Fiona note -->
+      <div class="glass-card rounded-2xl px-5 py-4 flex items-start gap-3">
+        <img src="https://i.pravatar.cc/100?img=32" class="w-9 h-9 rounded-full object-cover flex-shrink-0 mt-0.5" alt="Fiona">
+        <div>
+          <p class="text-xs font-bold text-slate-700 mb-1">Fiona · Project Coordinator</p>
+          <p class="text-sm text-slate-600 leading-relaxed">"Backyard Bill just confirmed the unit is set and level. Utility hookup begins Thursday. You're in the home stretch — just permits inspection left after that. Amazing day, Annie. 🏗"</p>
+        </div>
+      </div>
+
+      <!-- CTAs -->
+      <div class="space-y-3">
+        <a href="buyer_project_hub.html" class="block w-full text-center bg-blue-600 hover:bg-blue-700 text-white font-bold py-3.5 rounded-2xl transition-colors text-sm shadow-lg shadow-blue-200">
+          Back to My Project →
+        </a>
+        <button class="w-full text-center border border-slate-200 hover:border-slate-300 text-slate-700 font-semibold py-3.5 rounded-2xl transition-colors text-sm flex items-center justify-center gap-2">
+          <i data-lucide="share-2" class="w-4 h-4"></i>
+          Share Your Photo →
+        </button>
+      </div>
+
+    </div><!-- end state-set-complete -->
+
+  </main>
+
+  <!-- Toast -->
+  <div id="toast">Link copied!</div>
+
+  <script>
+    lucide.createIcons();
+
+    // ── Countdown timer ──────────────────────────────
+    const TARGET = new Date('2026-04-14T08:00:00-07:00'); // Pacific time
+
+    function pad(n) { return String(n).padStart(2, '0'); }
+
+    function updateCountdown() {
+      const now = new Date();
+      const diff = TARGET - now;
+      if (diff <= 0) {
+        document.getElementById('cd-days').textContent    = '00';
+        document.getElementById('cd-hours').textContent   = '00';
+        document.getElementById('cd-minutes').textContent = '00';
+        document.getElementById('cd-seconds').textContent = '00';
+        return;
+      }
+      const days    = Math.floor(diff / 86400000);
+      const hours   = Math.floor((diff % 86400000) / 3600000);
+      const minutes = Math.floor((diff % 3600000) / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      document.getElementById('cd-days').textContent    = pad(days);
+      document.getElementById('cd-hours').textContent   = pad(hours);
+      document.getElementById('cd-minutes').textContent = pad(minutes);
+      document.getElementById('cd-seconds').textContent = pad(seconds);
+    }
+
+    updateCountdown();
+    setInterval(updateCountdown, 1000);
+
+    // ── Copy share link ──────────────────────────────
+    function copyShareLink() {
+      navigator.clipboard.writeText('https://watch.yardstake.com/annie-adu-apr14').catch(() => {});
+      showToast('Link copied!');
+    }
+
+    function showToast(msg) {
+      const t = document.getElementById('toast');
+      t.textContent = msg;
+      t.classList.add('show');
+      setTimeout(() => t.classList.remove('show'), 2000);
+    }
+
+    // ── Confetti ─────────────────────────────────────
+    const CONFETTI_COLORS = ['#3B82F6','#06B6D4','#10B981','#F59E0B','#8B5CF6','#EC4899'];
+
+    function spawnConfetti() {
+      const container = document.getElementById('confetti-container');
+      container.innerHTML = '';
+      for (let i = 0; i < 28; i++) {
+        const piece = document.createElement('div');
+        piece.className = 'confetti-piece';
+        piece.style.cssText = `
+          left: ${Math.random() * 100}%;
+          top: 0;
+          background: ${CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)]};
+          animation-delay: ${Math.random() * 0.4}s;
+          animation-duration: ${0.9 + Math.random() * 0.6}s;
+          transform: rotate(${Math.random() * 360}deg);
+          border-radius: ${Math.random() > 0.5 ? '50%' : '2px'};
+        `;
+        container.appendChild(piece);
+      }
+    }
+
+    // ── State machine ─────────────────────────────────
+    const SWITCHER_BTNS = ['countdown','live','spectator','set-complete'];
+
+    function showState(id) {
+      // Hide all states
+      document.querySelectorAll('.state').forEach(el => el.classList.remove('active'));
+      document.getElementById('state-' + id).classList.add('active');
+      lucide.createIcons();
+
+      // Update switcher buttons
+      SWITCHER_BTNS.forEach(s => {
+        const btn = document.getElementById('btn-' + s);
+        if (!btn) return;
+        if (s === id) {
+          btn.classList.replace('bg-white', 'bg-blue-600');
+          btn.classList.replace('text-slate-600', 'text-white');
+          btn.classList.replace('border-slate-300', 'border-blue-600');
+        } else {
+          btn.classList.replace('bg-blue-600', 'bg-white');
+          btn.classList.replace('text-white', 'text-slate-600');
+          btn.classList.replace('border-blue-600', 'border-slate-300');
+        }
+      });
+
+      // Nav/tab-bar swap: spectator = logo only
+      const tabBar = document.getElementById('tab-bar');
+      const navAuth = document.getElementById('nav-authenticated');
+      if (id === 'spectator') {
+        tabBar.style.display = 'none';
+        navAuth.style.display = 'none';
+      } else {
+        tabBar.style.display = '';
+        navAuth.style.display = '';
+      }
+
+      // Confetti on set-complete entry
+      if (id === 'set-complete') spawnConfetti();
+    }
+
+    // Boot on countdown
+    showState('countdown');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

First of two PRs for `buyer_crane_day.html` (B-7 Crane Day split from #17).

Builds the file scaffold and two simpler states. States 2 (Live) and 2b (Spectator) are placeholder divs — filled in by PR #31 (issue #31, depends on this merging first).

## Changes

| File | Change |
|------|--------|
| `orchestration-v2/buyer/buyer_crane_day.html` | **New** — scaffold + States 1 and 3 |
| `orchestration-v2/buyer/RATIONALE.md` | **Updated** — Screen 10 entry (partial) |

## buyer_crane_day.html

**Scaffold:**
- 4-state machine: `countdown` / `live` / `spectator` / `set-complete`
- Demo state-switcher with active-state button highlighting
- `showState(id)` hides/shows states, swaps nav for spectator mode
- Spectator state: authenticated nav + tab bar hidden (logo only) — wired up and ready for #31 content

**State 1 — Countdown:**
- Live `setInterval` ticking to April 14, 2026 8:00 AM PST
- Delivery details card (date, location, unit, crane operator, what to expect)
- Fiona note card
- "Invite Friends & Family" share button → inline card with fake spectator URL + Copy Link (clipboard API + "Copied!" toast)

**State 3 — Set Complete:**
- CSS confetti burst fires on state entry (same pattern as `buyer_deposit.html`)
- Animated emerald pulse ring + "Your ADU is home! 🏠" heading
- Hero photo: ADU on foundation (Unsplash)
- Stats row: 8:00 AM start · 10:42 AM set · 2h 42min · Zero incidents
- Fiona wrap-up note
- "Back to My Project →" + "Share Your Photo →" CTAs

## Acceptance

- [x] Countdown timer ticks live from target date
- [x] Copy Link copies URL to clipboard and shows "Copied!" toast
- [x] State 3 confetti fires on state entry
- [x] Spectator nav/tab-bar hidden (logo only) when spectator state active
- [x] Demo switcher navigates all 4 states (2 + 2b show placeholders)
- [x] RATIONALE.md entry added for Screen 10

## Next

PR #31 (issue #31) fills in States 2 and 2b with live LIVE badge, GPS tracker, and chat simulation.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)